### PR TITLE
Require approval when backlog exists

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -97,6 +97,16 @@ a, a:visited {
     resize: none;
   }
 
+  .error {
+    color: red;
+    display: none;
+  }
+
+  .info {
+    color: #333;
+    display: none;
+  }
+
   .entry {
     margin: 24px 0;
   }

--- a/functions/api/guestbook.js
+++ b/functions/api/guestbook.js
@@ -1,27 +1,35 @@
 async function hasPriorPostToday(ip, env, date) {
   const today = date.toISOString().slice(0, 10);
-  const list = await env.GUESTBOOK.list();
-  for (const { name } of list.keys) {
-    const raw = await env.GUESTBOOK.get(name);
-    if (!raw) continue;
-    const entry = JSON.parse(raw);
-    if (entry.ip === ip && entry.timestamp?.slice(0, 10) === today) {
-      return true;
+  let cursor;
+  do {
+    const list = await env.GUESTBOOK.list({ prefix: 'entry-', cursor });
+    for (const { name } of list.keys) {
+      const raw = await env.GUESTBOOK.get(name);
+      if (!raw) continue;
+      const entry = JSON.parse(raw);
+      if (entry.ip === ip && entry.timestamp?.slice(0, 10) === today) {
+        return true;
+      }
     }
-  }
+    cursor = list.cursor;
+  } while (cursor);
   return false;
 }
 
 async function hasPendingApproval(env) {
-  const list = await env.GUESTBOOK.list();
-  for (const { name } of list.keys) {
-    const raw = await env.GUESTBOOK.get(name);
-    if (!raw) continue;
-    const entry = JSON.parse(raw);
-    if (entry.needsApproval && !entry.deleted) {
-      return true;
+  let cursor;
+  do {
+    const list = await env.GUESTBOOK.list({ prefix: 'entry-', cursor });
+    for (const { name } of list.keys) {
+      const raw = await env.GUESTBOOK.get(name);
+      if (!raw) continue;
+      const entry = JSON.parse(raw);
+      if (entry.needsApproval && !entry.deleted) {
+        return true;
+      }
     }
-  }
+    cursor = list.cursor;
+  } while (cursor);
   return false;
 }
 

--- a/guestbook.html
+++ b/guestbook.html
@@ -15,6 +15,7 @@ layout: default
     </div>
     <button type="submit">Sign Guestbook</button>
     <p class="error" id="error-message"></p>
+    <p class="info" id="info-message"></p>
   </form>
 
   <div class="entries" id="entries">
@@ -49,11 +50,18 @@ document.getElementById('guestbook-form').addEventListener('submit', async (e) =
 
     // Clear form, store deletion flag, and add new entry using server-provided data
     const newEntry = await response.json();
-    // Record ownership: map fingerprint to deletion key
     const pf = JSON.stringify([newEntry.timestamp, newEntry.name, newEntry.remarks]);
     localStorage.setItem(`guestbook-${pf}`, newEntry.key);
     e.target.reset();
-    prependEntry(newEntry);
+    const infoEl = document.getElementById('info-message');
+    if (newEntry.needsApproval) {
+      infoEl.textContent = 'Your entry will appear once approved.';
+      infoEl.style.display = 'block';
+    } else {
+      infoEl.style.display = 'none';
+      infoEl.textContent = '';
+      prependEntry(newEntry);
+    }
   } catch (error) {
     document.getElementById('error-message').textContent = error.message;
     document.getElementById('error-message').style.display = 'block';


### PR DESCRIPTION
## Summary
- queue new guestbook entries if any pending approvals exist
- inform users that their entry awaits approval

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845446626b883248dd3aac9768ae3d8