### PR TITLE
Fix garden reset values

### DIFF
--- a/assets/garden/garden.js
+++ b/assets/garden/garden.js
@@ -119,6 +119,9 @@
     seedBuyerRemainder = 0.0;
     lastSeedBuyerUpdate = Date.now();
     currentSeedBuyerRate = 0;
+    // Force UI updates for money and pot count
+    uiState.money = -1;
+    uiState.potCount = -1;
     renderPots();
     updatePotCompactness();
     update();


### PR DESCRIPTION
## Summary
- reset the garden's money and pot count when starting over

## Testing
- `npm test` *(fails: Missing script)*
- `bundle exec rake` *(fails: can't find executable rake)*

------
https://chatgpt.com/codex/tasks/task_e_6847a7a1a1d083249ab3db963f626f71