### PR TITLE
Add live rate stats

### DIFF
--- a/garden.html
+++ b/garden.html
@@ -41,7 +41,9 @@ title: The Garden
   <div id="sidebar">
     <div id="stats">
       Money: <span id="money">$0</span> <br>
+      <span id="money-rate-line" class="hidden">Money/sec: <span id="money-rate">0</span> <br></span>
       Seeds: <span id="seeds">1</span> <br>
+      <span id="seed-rate-line" class="hidden">Seeds/sec: <span id="seed-rate">0</span> <br></span>
       Pots: <span id="pot-count">1</span> <br>
       <span id="seeds-per-sec-line" class="hidden">Seeds/sec: <span id="seed-buyer-count">0</span> <span class="help-icon">?<span class="tooltip">Rate slows down as seeds accumulate</span></span> <br></span>
     </div>


### PR DESCRIPTION
## Summary
- show money/sec and seeds/sec in the garden
- compute rates from recent history

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6848a5b68b088324bb862bb1018906e2