### PR TITLE
Add hard delete to guestbook admin

### DIFF
--- a/functions/api/guestbook-admin.js
+++ b/functions/api/guestbook-admin.js
@@ -43,12 +43,16 @@ export async function onRequestGet({ request, env }) {
 
 export async function onRequestDelete({ request, env }) {
   try {
-    const { key, secret } = await request.json();
+    const { key, secret, hard } = await request.json();
     if (!key || !secret) {
       return new Response('Missing parameters', { status: 400 });
     }
     if (secret !== env.ADMIN_SECRET) {
       return new Response('Unauthorized', { status: 403 });
+    }
+    if (hard) {
+      await env.GUESTBOOK.delete(key);
+      return Response.json({ success: true });
     }
     const raw = await env.GUESTBOOK.get(key);
     if (!raw) {

--- a/guestbook-admin.html
+++ b/guestbook-admin.html
@@ -40,10 +40,10 @@ function entryHtml(e) {
     e.needsApproval ? 'needs-approval' : ''
   ].join(' ').trim();
   const buttons = e.deleted
-    ? '<button class="undelete">Un-delete</button>'
+    ? '<button class="undelete">Un-delete</button> <button class="hard-delete">Hard delete</button>'
     : e.needsApproval
-      ? '<button class="approve">Approve</button> <button class="delete">Delete</button>'
-      : '<button class="delete">Delete</button>';
+      ? '<button class="approve">Approve</button> <button class="delete">Delete</button> <button class="hard-delete">Hard delete</button>'
+      : '<button class="delete">Delete</button> <button class="hard-delete">Hard delete</button>';
   return `<div class="${classes}" data-key="${e.key}">
     <div class="name-timestamp">
       <div class="name">${escapeHtml(e.name)}</div>
@@ -79,6 +79,18 @@ document.getElementById('entries').addEventListener('click', async e => {
       localStorage.removeItem('gbAdminSecret');
       alert('Unauthorized: Invalid admin secret. Please refresh the page to re-enter.');
     } else alert('Failed to delete');
+  } else if (e.target.classList.contains('hard-delete')) {
+    if (!confirm('Permanently delete this entry?')) return;
+    const res = await fetch('/api/guestbook-admin', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key, secret: adminSecret, hard: true })
+    });
+    if (res.ok) loadEntries();
+    else if (res.status === 403) {
+      localStorage.removeItem('gbAdminSecret');
+      alert('Unauthorized: Invalid admin secret. Please refresh the page to re-enter.');
+    } else alert('Failed to hard delete');
   } else if (e.target.classList.contains('undelete')) {
     const res = await fetch('/api/guestbook-admin', {
       method: 'PUT',


### PR DESCRIPTION
## Summary
- allow hard deleting guestbook entries via admin API
- surface hard-delete button in the admin UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f57228ac0832482aeb45cb604f528