### PR TITLE
Add coverage step to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,12 @@ jobs:
 
     - name: Run tests
       run: npm test
+
+    - name: Run coverage
+      run: npm run test:coverage
+
+    - name: Upload coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: coverage/


### PR DESCRIPTION
## Summary
- run `npm run test:coverage` in CI
- upload coverage directory as an artifact

## Testing
- `npx vitest run`
- `npx vitest run --coverage` *(fails: Cannot find dependency '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_684f8ac705fc8324b6d4e31bd1e15784